### PR TITLE
Fix dev hydration and React warnings

### DIFF
--- a/app/components/head.tsx
+++ b/app/components/head.tsx
@@ -51,12 +51,6 @@ export const _Head: React.FC<Props> = ({
       <link rel="shortcut icon" href={`${url}/favicon.ico`} />
       <link rel="apple-touch-icon" href={`${url}/apple-touch-icon.png`} />
 
-      {/* Font */}
-      <link
-        href="https://fonts.googleapis.com/css2?family=Kaisei+Tokumin:wght@800&display=swap"
-        rel="stylesheet"
-      />
-
       {/* noindex */}
       {noindex && <meta key="robots" name="robots" content="noindex" />}
     </Head>

--- a/app/components/main.tsx
+++ b/app/components/main.tsx
@@ -5,7 +5,6 @@ import { Result } from './result'
 import { doGacha } from '../hooks/doGatya'
 import { Menu } from '../domain/Menu'
 import { Spinner } from './spinner'
-import CloseIcon from './close.svg'
 import * as gtag from '../lib/gtag'
 import _sleep from '../hooks/sleep'
 import { GoogleBoxAds, GoogleColumnAds, GoogleHeaderAds } from '../lib/gadsense'
@@ -63,7 +62,7 @@ export const Main: NextPage<Props> = ({ menus }) => {
       <Content>
         <GoogleHeaderAds />
         <Frame>
-          <MainContent isResult={isResult}>
+          <MainContent $isResult={isResult}>
             <TitleComponent>
               <Title>サイゼリヤ</Title>
               <Title>1000円ガチャ</Title>
@@ -74,8 +73,8 @@ export const Main: NextPage<Props> = ({ menus }) => {
               </ResultContent>
             )}
             <ButtonArea
-              isResult={isResult}
-              isButtonAreaFloat={isButtonAreaFloat}
+              $isResult={isResult}
+              $isButtonAreaFloat={isButtonAreaFloat}
             >
               <ButtonAreaContainer>
                 <Button
@@ -92,10 +91,12 @@ export const Main: NextPage<Props> = ({ menus }) => {
                   labelText={'アルコール類を除く'}
                 />
                 <CloseButton
+                  type="button"
+                  aria-label="閉じる"
                   onClick={() => {
                     handleCloseButton()
                   }}
-                  isInvisible={!isButtonAreaFloat}
+                  $isInvisible={!isButtonAreaFloat}
                 />
                 <FooterLink>
                   <a
@@ -140,7 +141,7 @@ const Content = styled.div`
 const ResultContent = styled.div`
   min-height: 80vh;
 `
-const MainContent = styled.div<{ isResult: boolean }>`
+const MainContent = styled.div<{ $isResult: boolean }>`
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -148,7 +149,7 @@ const MainContent = styled.div<{ isResult: boolean }>`
 
   // ガチャをしてない状態はタイトルを中央に配置
   ${(props) =>
-    !props.isResult &&
+    !props.$isResult &&
     css`
       flex-flow: column;
       justify-content: center;
@@ -157,15 +158,15 @@ const MainContent = styled.div<{ isResult: boolean }>`
     `}
 `
 const ButtonArea = styled.div<{
-  isResult: boolean
-  isButtonAreaFloat: boolean
+  $isResult: boolean
+  $isButtonAreaFloat: boolean
 }>`
   text-align: center;
 
   // ガチャ結果があるときはボタンを下に固定
   ${(props) =>
-    props.isResult &&
-    props.isButtonAreaFloat &&
+    props.$isResult &&
+    props.$isButtonAreaFloat &&
     css`
       position: sticky;
       bottom: 0px;
@@ -173,16 +174,39 @@ const ButtonArea = styled.div<{
       width: 100%;
     `}
 `
-const CloseButton = styled(CloseIcon)`
+const CloseButton = styled.button<{ $isInvisible: boolean }>`
   position: absolute;
   top: 10px;
   right: 10px;
   border-style: none;
-  font-size: 1em;
-  width: 1.5em;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0;
   border-radius: 90px;
+  background: transparent;
   color: rgba(0, 124, 0, 0.8);
-  display: ${({ isInvisible }) => (isInvisible ? 'none' : 'block')};
+  display: ${({ $isInvisible }) => ($isInvisible ? 'none' : 'block')};
+  cursor: pointer;
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 1rem;
+    height: 2px;
+    border-radius: 1px;
+    background: currentColor;
+  }
+
+  &::before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  &::after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
 `
 const ButtonAreaContainer = styled.div`
   position: relative;

--- a/app/lib/gadsense.tsx
+++ b/app/lib/gadsense.tsx
@@ -1,80 +1,103 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
+import Script from 'next/script'
 import styled from 'styled-components'
 import { device } from './../components/styled/media'
 
 export const GoogleAdsHeader = (): JSX.Element => (
   <>
-    <script
-      async
-      src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
-      data-ad-client="ca-pub-7961076646821939"
-    />
+    {process.env.NODE_ENV !== 'development' && (
+      <Script
+        async
+        src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
+        data-ad-client="ca-pub-7961076646821939"
+        strategy="afterInteractive"
+      />
+    )}
   </>
 )
 
 export const GoogleBoxAds = (): JSX.Element => {
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') {
-      try {
-        (window.adsbygoogle = window.adsbygoogle || []).push({})
-      } catch (err) {
-        console.error(err)
-      }
-    }
-  }, [])
+  const isMounted = useIsMounted()
+
+  useGoogleAds(isMounted)
 
   return (
-    <AdsBoxInsert
-      className="adsbygoogle"
-      data-ad-client="ca-pub-7961076646821939"
-      data-ad-slot="7072512565"
-      data-ad-format="auto"
-      data-full-width-responsive="true"
-    ></AdsBoxInsert>
+    <AdsBox>
+      {isMounted && (
+        <AdsBoxInsert
+          className="adsbygoogle"
+          data-ad-client="ca-pub-7961076646821939"
+          data-ad-slot="7072512565"
+          data-ad-format="auto"
+          data-full-width-responsive="true"
+        ></AdsBoxInsert>
+      )}
+    </AdsBox>
   )
 }
 
 export const GoogleHeaderAds = (): JSX.Element => {
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') {
-      try {
-        (window.adsbygoogle = window.adsbygoogle || []).push({})
-      } catch (err) {
-        console.error(err)
-      }
-    }
-  }, [])
+  const isMounted = useIsMounted()
+
+  useGoogleAds(isMounted)
 
   return (
-    <AdsHeaderInsert
-      className="adsbygoogle"
-      data-ad-client="ca-pub-7961076646821939"
-      data-ad-slot="1694695821"
-    ></AdsHeaderInsert>
+    <AdsHeader>
+      {isMounted && (
+        <AdsHeaderInsert
+          className="adsbygoogle"
+          data-ad-client="ca-pub-7961076646821939"
+          data-ad-slot="1694695821"
+        ></AdsHeaderInsert>
+      )}
+    </AdsHeader>
   )
 }
 
 export const GoogleColumnAds = (): JSX.Element => {
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') {
-      try {
-        (window.adsbygoogle = window.adsbygoogle || []).push({})
-      } catch (err) {
-        console.error(err)
-      }
-    }
-  }, [])
+  const isMounted = useIsMounted()
+
+  useGoogleAds(isMounted)
 
   return (
-    <AdsColumnInsert
-      className="adsbygoogle"
-      data-ad-client="ca-pub-7961076646821939"
-      data-ad-slot="7849040636"
-    ></AdsColumnInsert>
+    <AdsColumn>
+      {isMounted && (
+        <AdsColumnInsert
+          className="adsbygoogle"
+          data-ad-client="ca-pub-7961076646821939"
+          data-ad-slot="7849040636"
+        ></AdsColumnInsert>
+      )}
+    </AdsColumn>
   )
 }
 
-const AdsBoxInsert = styled.ins`
+const useIsMounted = (): boolean => {
+  const [isMounted, setIsMounted] = useState(false)
+
+  useEffect(() => {
+    setIsMounted(true)
+  }, [])
+
+  return isMounted
+}
+
+const useGoogleAds = (isMounted: boolean): void => {
+  useEffect(() => {
+    if (!isMounted || process.env.NODE_ENV === 'development') {
+      return
+    }
+
+    try {
+      const ads = (window.adsbygoogle = window.adsbygoogle || [])
+      ads.push({})
+    } catch (err) {
+      console.error(err)
+    }
+  }, [isMounted])
+}
+
+const AdsBox = styled.div`
   display: block;
   text-align: center;
   margin: 0 auto;
@@ -82,7 +105,13 @@ const AdsBoxInsert = styled.ins`
   height: 200px;
 `
 
-const AdsHeaderInsert = styled.ins`
+const AdsBoxInsert = styled.ins`
+  display: block;
+  width: 100%;
+  height: 100%;
+`
+
+const AdsHeader = styled.div`
   display: inline-block;
   min-width: 300px;
   max-width: 970px;
@@ -96,7 +125,13 @@ const AdsHeaderInsert = styled.ins`
   }
 `
 
-const AdsColumnInsert = styled.ins`
+const AdsHeaderInsert = styled.ins`
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+`
+
+const AdsColumn = styled.div`
   display: none;
   width: 0;
   height: 0;
@@ -106,4 +141,10 @@ const AdsColumnInsert = styled.ins`
     width: 300px;
     height: 600px;
   }
+`
+
+const AdsColumnInsert = styled.ins`
+  display: inline-block;
+  width: 100%;
+  height: 100%;
 `

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "dev": "PORT=3200 next dev",
+    "dev": "PORT=3200 next dev -H 127.0.0.1",
     "build": "next build",
     "production-build": "GENERATE_SOURCEMAP=false next build",
     "start": "PORT=3201 next start",

--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import Document, { DocumentContext } from 'next/document'
+import Document, {
+  DocumentContext,
+  Head,
+  Html,
+  Main,
+  NextScript,
+} from 'next/document'
 import { ServerStyleSheet } from 'styled-components'
 
 // https://styled-components.com/docs/advanced#nextjs
@@ -28,5 +34,22 @@ export default class MyDocument extends Document {
     } finally {
       sheet.seal()
     }
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head>
+          <link
+            href="https://fonts.googleapis.com/css2?family=Kaisei+Tokumin:wght@800&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
   }
 }


### PR DESCRIPTION
## Summary
- Load Google Fonts from `_document` instead of `next/head`
- Prevent styled-components control props from leaking to DOM nodes
- Render AdSense `<ins>` elements only after client mount to avoid hydration mismatch
- Bind `yarn dev` to `127.0.0.1` for local startup compatibility

## Verification
- `yarn lint`
- `yarn type-check`
- `yarn build`